### PR TITLE
V0.2.1 preparation

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,10 @@
 language: java
 jdk:
-  - openjdk7
-  - oraclejdk7
+# Tentatively ignore these environments as we face SSL errors
+# https://github.com/gradle/gradle/issues/2421
+#
+#  - openjdk7
+#  - oraclejdk7
   - oraclejdk8
 script:
   - ./gradlew test

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,9 @@
+language: java
+jdk:
+  - openjdk7
+  - oraclejdk7
+  - oraclejdk8
+script:
+  - ./gradlew test
+after_success:
+  - ./gradlew jacocoTestReport coveralls

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Mask filter plugin for Embulk
 
-mask columns with asterisks (still in initial development phase and missing basic functionalities to use in production )
+Mask columns with asterisks in a variety of patterns (still in initial development phase and missing basic features to use in production).
 
 ## Overview
 
@@ -8,15 +8,22 @@ mask columns with asterisks (still in initial development phase and missing basi
 
 ## Configuration
 
+*Caution* : Now we use `type` to specify mask types such as `all` and `email`, instead of `pattern` which was used in version 0.1.1 or earlier.
+
 - **columns**: target columns which would be replaced with asterisks (string, required)
   - **name**: name of the column (string, required)
-  - **type**: mask type, `all` or `email` (string, default: `all`)
+  - **type**: mask type, `all`, `email`, `regex` or `substring` (string, default: `all`)
   - **paths**: list of JSON path and type, works if the column type is JSON
     - `[{key: $.json_path1}, {key: $.json_path2}]` would mask both `$.json_path1` and `$.json_path2` nodes
     - Elements under the nodes would be converted to string and then masked (e.g., `[0,1,2]` -> `*******`)
-  - **length**: if specified, this filter replaces the column with fixed number of asterisks (integer, optional)
+  - **length**: if specified, this filter replaces the column with fixed number of asterisks (integer, optional. supported only in `all`, `email`, `substring`.)
+  - **pattern**: Regex pattern such as "[0-9]+" (string, required for `regex` type)
+  - **start**: The beginning index for `substring` type. The value starts from 0 and inclusive (integer, default: 0)
+  - **end**: The ending index for `substring` type. The value is exclusive (integer, default: length of the target column)
 
 ## Example
+
+
 
 If you have below data in csv or other format file,
 
@@ -48,6 +55,26 @@ would produce
 | Elizabeth |	*** | female | ** | *****@example.com |
 | Christian | **** | male | ** | *****@example.com |
 | Amy |	***** | female | ** | *****@example.com |
+
+If you use `regex` or `substring` types,
+
+```yaml
+filters:
+  - type: mask
+    columns:
+      - { name: last_name, type: regex, pattern: "[a-z]"}
+      - { name: contact, type: substring, start: 5, length: 5}
+```
+
+would produce
+
+|first_name | last_name | gender | age | contact |
+|---|---|---|---|---|
+| B******* | Bell | male | 30 | bell.***** |
+| L**** | Duncan | male | 20 | lucas***** |
+| E******* |	May | female | 25 | eliza***** |
+| C******** | Reid | male | 15 | chris***** |
+| A** |	Avery | female | 40 | amy.a***** |
 
 JSON type column is also partially supported.
 

--- a/README.md
+++ b/README.md
@@ -10,8 +10,8 @@ mask columns with asterisks (still in initial development phase and missing basi
 
 - **columns**: target columns which would be replaced with asterisks (string, required)
   - **name**: name of the column (string, required)
-  - **pattern**: mask pattern, `all` or `email` (string, default: `all`)
-  - **paths**: list of JSON path and pattern, works if the column type is JSON
+  - **type**: mask type, `all` or `email` (string, default: `all`)
+  - **paths**: list of JSON path and type, works if the column type is JSON
     - `[{key: $.json_path1}, {key: $.json_path2}]` would mask both `$.json_path1` and `$.json_path2` nodes
     - Elements under the nodes would be converted to string and then masked (e.g., `[0,1,2]` -> `*******`)
   - **length**: if specified, this filter replaces the column with fixed number of asterisks (integer, optional)
@@ -36,7 +36,7 @@ filters:
     columns:
       - { name: last_name}
       - { name: age}
-      - { name: contact, pattern: email, length: 5}
+      - { name: contact, type: email, length: 5}
 ```
 
 would produce
@@ -71,7 +71,7 @@ below filter configuration
 filters:
   - type: mask
     columns:
-      - { name: user, paths: [{key: $.full_name.first_name}, {key: $.email, pattern: email}]}    
+      - { name: user, paths: [{key: $.full_name.first_name}, {key: $.email, type: email}]}    
 ```
 
 would produce

--- a/build.gradle
+++ b/build.gradle
@@ -26,6 +26,13 @@ dependencies {
     testCompile "org.embulk:embulk-core:0.8.29:tests"
 }
 
+jacocoTestReport {
+    reports {
+        xml.enabled = true // coveralls plugin depends on xml format report
+        html.enabled = true
+    }
+}
+
 task classpath(type: Copy, dependsOn: ["jar"]) {
     doFirst { file("classpath").deleteDir() }
     from (configurations.runtime - configurations.provided + files(jar.archivePath))

--- a/build.gradle
+++ b/build.gradle
@@ -15,7 +15,7 @@ configurations {
     provided
 }
 
-version = "0.1.1"
+version = "0.2.1"
 
 sourceCompatibility = 1.7
 targetCompatibility = 1.7

--- a/build.gradle
+++ b/build.gradle
@@ -3,6 +3,7 @@ plugins {
     id "com.github.jruby-gradle.base" version "0.1.5"
     id "java"
     id "checkstyle"
+    id "jacoco"
 }
 import com.github.jrubygradle.JRubyExec
 repositories {

--- a/build.gradle
+++ b/build.gradle
@@ -19,11 +19,11 @@ sourceCompatibility = 1.7
 targetCompatibility = 1.7
 
 dependencies {
-    compile  "org.embulk:embulk-core:0.8.15"
-    provided "org.embulk:embulk-core:0.8.15"
+    compile  "org.embulk:embulk-core:0.8.29"
+    provided "org.embulk:embulk-core:0.8.29"
     compile "com.jayway.jsonpath:json-path:2.+"
     testCompile "junit:junit:4.+"
-    testCompile "org.embulk:embulk-core:0.8.15:tests"
+    testCompile "org.embulk:embulk-core:0.8.29:tests"
 }
 
 task classpath(type: Copy, dependsOn: ["jar"]) {

--- a/build.gradle
+++ b/build.gradle
@@ -1,6 +1,7 @@
 plugins {
     id "com.jfrog.bintray" version "1.1"
     id "com.github.jruby-gradle.base" version "0.1.5"
+    id "com.github.kt3k.coveralls" version "2.8.1"
     id "java"
     id "checkstyle"
     id "jacoco"

--- a/src/main/java/org/embulk/filter/mask/MaskFilterPlugin.java
+++ b/src/main/java/org/embulk/filter/mask/MaskFilterPlugin.java
@@ -33,9 +33,21 @@ public class MaskFilterPlugin implements FilterPlugin {
         @ConfigDefault("\"all\"")
         Optional<String> getType();
 
+        @Config("pattern")
+        @ConfigDefault("\"all\"")
+        Optional<String> getPattern();
+
         @Config("length")
         @ConfigDefault("null")
         Optional<Integer> getLength();
+
+        @Config("start")
+        @ConfigDefault("null")
+        Optional<Integer> getStart();
+
+        @Config("end")
+        @ConfigDefault("null")
+        Optional<Integer> getEnd();
 
         @Config("paths")
         @ConfigDefault("null")

--- a/src/main/java/org/embulk/filter/mask/MaskFilterPlugin.java
+++ b/src/main/java/org/embulk/filter/mask/MaskFilterPlugin.java
@@ -30,12 +30,8 @@ public class MaskFilterPlugin implements FilterPlugin {
         String getName();
 
         @Config("type")
-        @ConfigDefault("\"string\"")
-        Optional<String> getType();
-
-        @Config("pattern")
         @ConfigDefault("\"all\"")
-        Optional<String> getPattern();
+        Optional<String> getType();
 
         @Config("length")
         @ConfigDefault("null")

--- a/src/main/java/org/embulk/filter/mask/MaskPageOutput.java
+++ b/src/main/java/org/embulk/filter/mask/MaskPageOutput.java
@@ -121,9 +121,9 @@ public class MaskPageOutput implements PageOutput {
 
     private String maskAsString(String name, Object value) {
         MaskColumn maskColumn = maskColumnMap.get(name);
-        String pattern = maskColumn.getPattern().get();
+        String type = maskColumn.getType().get();
         int maskLength = maskColumn.getLength().or(0);
-        return mask(value, pattern, maskLength);
+        return mask(value, type, maskLength);
     }
 
     private Value maskAsJson(String name, Value value) {
@@ -133,11 +133,11 @@ public class MaskPageOutput implements PageOutput {
 
         for (Map<String, String> path : paths) {
             String key = path.get("key");
-            String pattern = path.containsKey("pattern") ? path.get("pattern") : "all";
+            String type = path.containsKey("type") ? path.get("type") : "all";
             int maskLength = path.containsKey("length") ? Integer.parseInt(path.get("length")) : 0;
             Object element = context.read(key);
             if (!key.equals("$") && element != null) {
-                String maskedValue = mask(element, pattern, maskLength);
+                String maskedValue = mask(element, type, maskLength);
                 context.set(key, new TextNode(maskedValue).asText()).jsonString();
             }
         }
@@ -154,17 +154,17 @@ public class MaskPageOutput implements PageOutput {
         builder.close();
     }
 
-    private String mask(Object value, String pattern, Integer length) {
+    private String mask(Object value, String type, Integer length) {
         String maskedValue;
         String nakedValue = value.toString();
-        if (pattern.equals("email")) {
+        if (type.equals("email")) {
             if (length > 0) {
                 String maskPattern = StringUtils.repeat("*", length) + "@$1";
                 maskedValue = nakedValue.replaceFirst("^.+?@(.+)$", maskPattern);
             } else {
                 maskedValue = nakedValue.replaceAll(".(?=[^@]*@)", "*");
             }
-        } else if (pattern.equals("all")) {
+        } else if (type.equals("all")) {
             if (length > 0) {
                 maskedValue = StringUtils.repeat("*", length);
             } else {

--- a/src/main/java/org/embulk/filter/mask/MaskPageOutput.java
+++ b/src/main/java/org/embulk/filter/mask/MaskPageOutput.java
@@ -7,6 +7,7 @@ import org.embulk.config.TaskSource;
 import org.embulk.spi.*;
 import org.embulk.spi.json.JsonParser;
 import org.embulk.spi.time.Timestamp;
+import org.embulk.spi.type.Type;
 import org.embulk.spi.type.Types;
 import org.embulk.filter.mask.MaskFilterPlugin.*;
 import org.msgpack.value.Value;
@@ -67,62 +68,80 @@ public class MaskPageOutput implements PageOutput {
                 continue;
             }
 
-            Object inputValue;
-            if (Types.STRING.equals(inputColumn.getType())) {
+            String name = inputColumn.getName();
+            Type type = inputColumn.getType();
+
+            if (Types.STRING.equals(type)) {
                 final String value = reader.getString(inputColumn);
-                inputValue = value;
-                builder.setString(inputColumn, value);
-            } else if (Types.BOOLEAN.equals(inputColumn.getType())) {
-                final boolean value = reader.getBoolean(inputColumn);
-                inputValue = value;
-                builder.setBoolean(inputColumn, value);
-            } else if (Types.DOUBLE.equals(inputColumn.getType())) {
-                final double value = reader.getDouble(inputColumn);
-                inputValue = value;
-                builder.setDouble(inputColumn, value);
-            } else if (Types.LONG.equals(inputColumn.getType())) {
-                final long value = reader.getLong(inputColumn);
-                inputValue = value;
-                builder.setLong(inputColumn, value);
-            } else if (Types.TIMESTAMP.equals(inputColumn.getType())) {
-                final Timestamp value = reader.getTimestamp(inputColumn);
-                inputValue = value;
-                builder.setTimestamp(inputColumn, value);
-            } else if (Types.JSON.equals(inputColumn.getType())) {
-                final Value value = reader.getJson(inputColumn);
-                inputValue = value;
-                builder.setJson(inputColumn, value);
-            } else {
-                throw new DataException("Unexpected type:" + inputColumn.getType());
-            }
-
-            if (maskColumnMap.containsKey(inputColumn.getName())) {
-                MaskColumn maskColumn = maskColumnMap.get(inputColumn.getName());
-
-                if (Types.JSON.equals(inputColumn.getType())) {
-                    Value inputJson = (Value) inputValue;
-                    DocumentContext context = parseContext.parse(inputJson.toJson());
-                    List<Map<String, String>> paths = maskColumn.getPaths().or(new ArrayList<Map<String, String>>());
-
-                    for (Map<String, String> path : paths) {
-                        String key = path.get("key");
-                        String pattern = path.containsKey("pattern") ? path.get("pattern") : "all";
-                        int maskLength = path.containsKey("length") ? Integer.parseInt(path.get("length")) : 0;
-                        Object element = context.read(key);
-                        if (!key.equals("$") && element != null) {
-                            String maskedValue = mask(element, pattern, maskLength);
-                            String maskedJson = context.set(key, new TextNode(maskedValue).asText()).jsonString();
-                            builder.setJson(inputColumn, jsonParser.parse(maskedJson));
-                        }
-                    }
+                if (maskColumnMap.containsKey(name)) {
+                    builder.setString(inputColumn, maskAsString(name, value));
                 } else {
-                    String pattern = maskColumn.getPattern().get();
-                    int maskLength = maskColumn.getLength().or(0);
-                    String maskedString = mask(inputValue, pattern, maskLength);
-                    builder.setString(inputColumn, maskedString);
+                    builder.setString(inputColumn, value);
                 }
+            } else if (Types.BOOLEAN.equals(type)) {
+                final boolean value = reader.getBoolean(inputColumn);
+                if (maskColumnMap.containsKey(name)) {
+                    builder.setString(inputColumn, maskAsString(name, value));
+                } else {
+                    builder.setBoolean(inputColumn, value);
+                }
+            } else if (Types.DOUBLE.equals(type)) {
+                final double value = reader.getDouble(inputColumn);
+                if (maskColumnMap.containsKey(name)) {
+                    builder.setString(inputColumn, maskAsString(name, value));
+                } else {
+                    builder.setDouble(inputColumn, value);
+                }
+            } else if (Types.LONG.equals(type)) {
+                final long value = reader.getLong(inputColumn);
+                if (maskColumnMap.containsKey(name)) {
+                    builder.setString(inputColumn, maskAsString(name, value));
+                } else {
+                    builder.setLong(inputColumn, value);
+                }
+            } else if (Types.TIMESTAMP.equals(type)) {
+                final Timestamp value = reader.getTimestamp(inputColumn);
+                if (maskColumnMap.containsKey(name)) {
+                    builder.setString(inputColumn, maskAsString(name, value));
+                } else {
+                    builder.setTimestamp(inputColumn, value);
+                }
+            } else if (Types.JSON.equals(type)) {
+                final Value value = reader.getJson(inputColumn);
+                if (maskColumnMap.containsKey(name)) {
+                    builder.setJson(inputColumn, maskAsJson(name, value));
+                } else {
+                    builder.setJson(inputColumn, value);
+                }
+            } else {
+                throw new DataException("Unexpected type:" + type);
             }
         }
+    }
+
+    private String maskAsString(String name, Object value) {
+        MaskColumn maskColumn = maskColumnMap.get(name);
+        String pattern = maskColumn.getPattern().get();
+        int maskLength = maskColumn.getLength().or(0);
+        return mask(value, pattern, maskLength);
+    }
+
+    private Value maskAsJson(String name, Value value) {
+        MaskColumn maskColumn = maskColumnMap.get(name);
+        DocumentContext context = parseContext.parse(value.toJson());
+        List<Map<String, String>> paths = maskColumn.getPaths().or(new ArrayList<Map<String, String>>());
+
+        for (Map<String, String> path : paths) {
+            String key = path.get("key");
+            String pattern = path.containsKey("pattern") ? path.get("pattern") : "all";
+            int maskLength = path.containsKey("length") ? Integer.parseInt(path.get("length")) : 0;
+            Object element = context.read(key);
+            if (!key.equals("$") && element != null) {
+                String maskedValue = mask(element, pattern, maskLength);
+                context.set(key, new TextNode(maskedValue).asText()).jsonString();
+            }
+        }
+        return jsonParser.parse(context.jsonString());
     }
 
     @Override

--- a/src/test/java/org/embulk/filter/mask/TestMaskFilterPlugin.java
+++ b/src/test/java/org/embulk/filter/mask/TestMaskFilterPlugin.java
@@ -262,8 +262,8 @@ public class TestMaskFilterPlugin {
                 "columns:\n" +
                 "  - { name: _c0}\n" +
                 "  - { name: _c1, paths: [{key: $.root.key1}]}\n" +
-                "  - { name: _c2, paths: [{key: $.root.key3, length: 2}, {key: $.root.key4, pattern: all}]}\n" +
-                "  - { name: _c3, paths: [{key: $.root.key1}, {key: $.root.key3.key7, pattern: email, length: 3}]}\n";
+                "  - { name: _c2, paths: [{key: $.root.key3, length: 2}, {key: $.root.key4, type: all}]}\n" +
+                "  - { name: _c3, paths: [{key: $.root.key1}, {key: $.root.key3.key7, type: email, length: 3}]}\n";
 
         ConfigSource config = getConfigFromYaml(configYaml);
 
@@ -323,9 +323,9 @@ public class TestMaskFilterPlugin {
         String configYaml = "" +
                 "type: mask\n" +
                 "columns:\n" +
-                "  - { name: _c0, pattern: email}\n" +
-                "  - { name: _c1, pattern: email}\n" +
-                "  - { name: _c2, pattern: all}\n" +
+                "  - { name: _c0, type: email}\n" +
+                "  - { name: _c1, type: email}\n" +
+                "  - { name: _c2, type: all}\n" +
                 "  - { name: _c3}\n";
 
         ConfigSource config = getConfigFromYaml(configYaml);


### PR DESCRIPTION
- Build with the latest embulk library (0.8.29)
- Stop using `pattern` to specify mask types (use `type` instead, `pattern` is only used with `regex` type)
- Support `regex` and `substring` types
- CI integration